### PR TITLE
Support for custom .vue blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # require-extension-hooks-vue
-Simple parser for vue files
+Simple parser for vue files  
 
 Using require-extension-hooks you can load *.vue* files in node, extremely helpful for browserless unit testing.
 
-## Installation
-`npm install require-extension-hooks require-extension-hooks-vue --save-dev`
+## Installation  
+`npm install require-extension-hooks require-extension-hooks-vue --save-dev`  
 
-## Usage
+## Usage  
 ```javascript
 const hooks = require('require-extension-hooks');
 hooks('vue').plugin('vue');
@@ -42,26 +42,29 @@ hooks('ts').push(function({content}){
 /* transpile your script code here */
 });
 ```
-
-For custom blocks in `.vue` files, add other require hooks for the name of the blocks,
-prefixed by `vue-block-`. For example, to load a custom `<json></json>` block:
-
-```javascript
-const hooks = require('require-extension-hooks');
-hooks('vue').plugin('vue');
-hooks('vue-block-json').push(({ content }) => {
-    // Strings returned here will be appended to the compiled .vue file. This should return JavaScript, in a string.
-    return '';
-});
-```
-
-You can access the exported options object using (as vue-template-compiler does itself):
-```javascript
-((module.exports.default || module.exports).options || module.exports.default || module.exports)
-```
-
-
 *There will likely be additional hook libraries for script languages available soon*
+
+## Custom Blocks
+If you have custom blocks in your `.vue` files, you can parse then using `require-extension-hooks`.
+Blocks are available by hooking to the file type `vue-block-(block name)`. The hook should return
+JavaScript code, in a string, which will be appended to the compiled `.vue` file.
+
+A helper named `COMPONENT_OPTIONS` is available in on the plugin export to allow you to modify
+the exported component options object from the `.vue` file.
+
+For example, for a `<json></json>` block to have its data available via `this.json` in the
+component, you could use a [mixin](https://vuejs.org/v2/guide/mixins.html):
+
+```javascript
+const { COMPONENT_OPTIONS } = require('require-extension-hooks-vue');
+hooks('vue-block-json').push(({ content }) =>
+    `${COMPONENT_OPTIONS}.mixins = (${COMPONENT_OPTIONS}.mixins || []).concat({
+        data: () => ({
+            json: ${JSON.parse(content)}
+        })
+    });`
+);
+```
 
 ## Register
 You can automatically register the vue hook using the register file:
@@ -81,9 +84,9 @@ plugin.configure({ transpileTemplates: false });
 ```
 
 ### transpileTemplates
-`true`
+`true`  
 whether or not to automatically transpile templates that have a `lang` attribute
 
 ### sourceMaps
-`true`
+`true`  
 whether or not to set up source map support. This utilises the `source-map-support` library.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # require-extension-hooks-vue
-Simple parser for vue files  
+Simple parser for vue files
 
 Using require-extension-hooks you can load *.vue* files in node, extremely helpful for browserless unit testing.
 
-## Installation  
-`npm install require-extension-hooks require-extension-hooks-vue --save-dev`  
+## Installation
+`npm install require-extension-hooks require-extension-hooks-vue --save-dev`
 
-## Usage  
+## Usage
 ```javascript
 const hooks = require('require-extension-hooks');
 hooks('vue').plugin('vue');
@@ -42,6 +42,25 @@ hooks('ts').push(function({content}){
 /* transpile your script code here */
 });
 ```
+
+For custom blocks in `.vue` files, add other require hooks for the name of the blocks,
+prefixed by `vue-block-`. For example, to load a custom `<json></json>` block:
+
+```javascript
+const hooks = require('require-extension-hooks');
+hooks('vue').plugin('vue');
+hooks('vue-block-json').push(({ content }) => {
+    // Strings returned here will be appended to the compiled .vue file. This should return JavaScript, in a string.
+    return '';
+});
+```
+
+You can access the exported options object using (as vue-template-compiler does itself):
+```javascript
+((module.exports.default || module.exports).options || module.exports.default || module.exports)
+```
+
+
 *There will likely be additional hook libraries for script languages available soon*
 
 ## Register
@@ -62,9 +81,9 @@ plugin.configure({ transpileTemplates: false });
 ```
 
 ### transpileTemplates
-`true`  
+`true`
 whether or not to automatically transpile templates that have a `lang` attribute
 
 ### sourceMaps
-`true`  
+`true`
 whether or not to set up source map support. This utilises the `source-map-support` library.

--- a/spec/custom-blocks.spec.js
+++ b/spec/custom-blocks.spec.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import hooks from 'require-extension-hooks';
 
-hooks('vue-json').push(function ({ content }) {
+hooks('vue-block-json').push(function ({ content }) {
   // This is how vue-template-compiler gets the options
   const options = '((module.exports.default || module.exports).options || module.exports.default || module.exports)';
   const value = JSON.parse(content).value;

--- a/spec/custom-blocks.spec.js
+++ b/spec/custom-blocks.spec.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import hooks from 'require-extension-hooks';
+
+hooks('vue-json').push(function ({ content }) {
+  // This is how vue-template-compiler gets the options
+  const options = '((module.exports.default || module.exports).options || module.exports.default || module.exports)';
+  const value = JSON.parse(content).value;
+  return options + '.name = ' + JSON.stringify(value) + ';';
+});
+
+const CustomBlock = require('./vue-files/custom-block').default;
+
+test('transpiles using another hook', t => {
+  t.is(CustomBlock.name, 'custom');
+});

--- a/spec/custom-blocks.spec.js
+++ b/spec/custom-blocks.spec.js
@@ -1,11 +1,10 @@
 import test from 'ava';
 import hooks from 'require-extension-hooks';
+import { COMPONENT_OPTIONS } from '../';
 
-hooks('vue-block-json').push(function ({ content }) {
-  // This is how vue-template-compiler gets the options
-  const options = '((module.exports.default || module.exports).options || module.exports.default || module.exports)';
+hooks('vue-block-json-name').push(function ({ content }) {
   const value = JSON.parse(content).value;
-  return options + '.name = ' + JSON.stringify(value) + ';';
+  return COMPONENT_OPTIONS + '.name = ' + JSON.stringify(value) + ';';
 });
 
 const CustomBlock = require('./vue-files/custom-block').default;

--- a/spec/vue-files/custom-block.vue
+++ b/spec/vue-files/custom-block.vue
@@ -4,6 +4,6 @@
 <script>
 export default {};
 </script>
-<json>
+<json-name>
 { "value": "custom" }
-</json>
+</json-name>

--- a/spec/vue-files/custom-block.vue
+++ b/spec/vue-files/custom-block.vue
@@ -1,0 +1,9 @@
+<template>
+    <div>Custom block in vue file</div>
+</template>
+<script>
+export default {};
+</script>
+<json>
+{ "value": "custom" }
+</json>

--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,13 @@ function processCustomBlocks (
 ) {
   if (!customBlocks)
     return '';
-  return customBlocks.map(customBlock => hook('vue-block-' + customBlock.type, customBlock.content)).join('\n');
+  return customBlocks.map(customBlock => {
+    try {
+      return hook('vue-block-' + customBlock.type, customBlock.content);
+    } catch (err) {
+      return '';
+    }
+  }).join('\n');
 }
 
 module.exports = ({ content, filename, hook }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const transpile = require('vue-template-es2015-compiler');
 const postcss = require('postcss');
 const postcssModules = require('postcss-modules-sync').default;
 
-const exportsTarget = '((module.exports.default || module.exports).options || module.exports.default || module.exports)';
+const COMPONENT_OPTIONS = '((module.exports.default || module.exports).options || module.exports.default || module.exports)';
 
 const defaultConfig = {
   transpileTemplates: true,
@@ -123,9 +123,9 @@ function getCompiledTemplate(
 
   return [
     ';',
-    transpile(`${exportsTarget}.render=${renderFn};`),
-    transpile(`${exportsTarget}.staticRenderFns = [ ${staticRenderFns} ];`),
-    `${exportsTarget}.render._withStripped = true;`,
+    transpile(`${COMPONENT_OPTIONS}.render=${renderFn};`),
+    transpile(`${COMPONENT_OPTIONS}.staticRenderFns = [ ${staticRenderFns} ];`),
+    `${COMPONENT_OPTIONS}.render._withStripped = true;`,
   ].join('\n');
 }
 
@@ -157,14 +157,14 @@ function getCssModuleComputedProps(
         })).process(content).css;
       const cssClassesStr = JSON.stringify(cssClasses);
 
-      return `${exportsTarget}.computed.${moduleName} = function(){ return ${cssClassesStr}; };`;
+      return `${COMPONENT_OPTIONS}.computed.${moduleName} = function(){ return ${cssClassesStr}; };`;
     });
 
   if (!computedProps.length) {
     return '';
   }
 
-  return `${exportsTarget}.computed = ${exportsTarget}.computed || {}; ${computedProps.join(' ')}`;
+  return `${COMPONENT_OPTIONS}.computed = ${COMPONENT_OPTIONS}.computed || {}; ${computedProps.join(' ')}`;
 }
 
 function processCustomBlocks (
@@ -235,3 +235,5 @@ module.exports = ({ content, filename, hook }) => {
 module.exports.configure = (config) => {
   globalConfig = Object.assign({}, defaultConfig, globalConfig, config);
 };
+
+module.exports.COMPONENT_OPTIONS = COMPONENT_OPTIONS;

--- a/src/index.js
+++ b/src/index.js
@@ -167,11 +167,22 @@ function getCssModuleComputedProps(
   return `${exportsTarget}.computed = ${exportsTarget}.computed || {}; ${computedProps.join(' ')}`;
 }
 
+function processCustomBlocks (
+  filename,
+  hook,
+  customBlocks
+) {
+  if (!customBlocks)
+    return '';
+  return customBlocks.map(customBlock => hook('vue-block-' + customBlock.type, customBlock.content)).join('\n');
+}
+
 module.exports = ({ content, filename, hook }) => {
   const {
     template,
     script,
     styles,
+    customBlocks,
   } = compiler.parseComponent(content, { pad: 'line' });
 
   if (globalConfig.sourceMaps && sourceMapSupport === false) {
@@ -187,7 +198,7 @@ module.exports = ({ content, filename, hook }) => {
     script
   );
 
-  const compliledTemplate = getCompiledTemplate(
+  const compiledTemplate = getCompiledTemplate(
     filename,
     hook,
     template
@@ -199,10 +210,17 @@ module.exports = ({ content, filename, hook }) => {
     styles
   );
 
+  const processedCustomBlocks = processCustomBlocks(
+    filename,
+    hook,
+    customBlocks
+  );
+
   const result = [
     scriptPart,
-    compliledTemplate,
+    compiledTemplate,
     cssModulesComputedProps,
+    processedCustomBlocks,
   ].join('\n');
 
   return { content: result };


### PR DESCRIPTION
I've added support for custom `<blocks>` in `.vue` files.

It piggybacks on top of require-extension-hooks too, and prefixes the block names with `vue-block-`. So for example if you add a hook for `vue-block-json`, then you can parse a `<json>` block and do whatever you like with it.

The return value of the hook is appended to the compiled `.vue` file, so you can run anything you like in there.

What do you think?